### PR TITLE
feat/add-avatar-possession

### DIFF
--- a/service.py
+++ b/service.py
@@ -88,6 +88,8 @@ class NamePossessionService:
         if not await self.set_group_card(client, group_id, int(self_id), target_name):
             return None
 
+        await self.set_avatar(client, target_id)
+
         # log after successful rename
         logger.info(
             f"namepossession: set_group_card success group={group_id} self={self_id} "
@@ -96,3 +98,14 @@ class NamePossessionService:
 
         await self.poke_user(client, group_id, target_id)
         return target_id, target_name
+
+    async def set_avatar(self, client, target_id):
+        payloads = {
+            "file": f"https://q1.qlogo.cn/g?b=qq&nk={target_id}&s=640"
+        }
+        try:
+            await client.api.call_action('set_qq_avatar', **payloads)
+            return True
+        except Exception as e:
+            logger.warning(f"[namepossession] 在切换头像时遇到报错e:{e}")
+            return False

--- a/service.py
+++ b/service.py
@@ -107,5 +107,5 @@ class NamePossessionService:
             await client.api.call_action('set_qq_avatar', **payloads)
             return True
         except Exception as e:
-            logger.warning(f"[namepossession] 在切换头像时遇到报错e:{e}")
+            logger.warning(f"Error occurred while switching avatar: {e}", exc_info=True)
             return False


### PR DESCRIPTION
- 实现头像夺舍功能
Fixes #1

运行截图
<img width="1225" height="262" alt="59055163aa765bc75c5f0066e108aec8" src="https://github.com/user-attachments/assets/1d17b6a1-a8b7-4c2e-b1e3-c5b30aa29747" />
<img width="1244" height="261" alt="311f71aabb770071c02b8b3cf3181cc0" src="https://github.com/user-attachments/assets/bcc73394-df42-4e7b-99d6-177320bc7a7c" />

## Summary by Sourcery

新功能：
- 在执行随机附身时，将机器人头像更新为目标用户的 QQ 头像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Update the bot avatar to the target user's QQ avatar when performing random possession.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 新增头像设置功能，允许用户自定义和更新其QQ平台头像。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->