### PR TITLE
feat: 增加细分配置开关：夺舍群昵称、夺舍头像

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 注意：本插件仅在 QQ(OneBot/Napcat) 平台生效；不会伪装为其他用户发言，只会修改机器人自己的群名片。
 
 配置（AstrBot WebUI → 插件管理 → namepossession）
-- auto_enabled: 是否启用定时随机“夺舍”（通过配置控制，不提供手动开启/关闭指令）。
-- group_mode: 群名单模式，`whitelist`/`blacklist`/`none`。
-- group_list: 群号列表（数字或字符串均可），与 `group_mode` 共同生效。
-- auto_interval: 随机间隔（分钟）区间，包含 `min_minutes` 与 `max_minutes`。
+- `is_parody_nickname`：是否夺舍群昵称
+- `is_parody_avatar`：是否夺舍头像
+- `auto_enabled`: 是否启用定时随机“夺舍”（通过配置控制，不提供手动开启/关闭指令）。
+- `group_mode`: 群名单模式，`whitelist`/`blacklist`/`none`。
+- `group_list`: 群号列表（数字或字符串均可），与 `group_mode` 共同生效。
+- `auto_interval`: 随机间隔（分钟）区间，包含 `min_minutes` 与 `max_minutes`。
 
 行为说明
 - 定时模式：插件按配置的随机间隔，在允许的群中随机挑选一群执行一次“夺舍”。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,4 +1,14 @@
 {
+  "is_parody_nickname": {
+    "description": "是否夺舍群昵称",
+    "type": "bool",
+    "default": true
+  },
+  "is_parody_avatar": {
+    "description": "是否夺舍头像",
+    "type": "bool",
+    "default": false
+  },
   "auto_enabled": {
     "description": "是否启用随机夺舍",
     "type": "bool",
@@ -7,7 +17,11 @@
   "group_mode": {
     "description": "群名单模式",
     "type": "string",
-    "options": ["whitelist", "blacklist", "none"],
+    "options": [
+      "whitelist",
+      "blacklist",
+      "none"
+    ],
     "default": "none"
   },
   "group_list": {

--- a/main.py
+++ b/main.py
@@ -24,6 +24,9 @@ class NamePossessionPlugin(Star):
         self.store = StateStore(os.path.join(base_dir, "data", "state.json"))
         self.service = NamePossessionService()
         self.config = config
+        self.is_parody_nickname = self.config.get("is_parody_nickname", True)
+        self.is_parody_avatar = self.config.get("is_parody_avatar", False)
+        self.config.get("is_parody_avatar")
         self._auto_task: asyncio.Task | None = None
         if self._is_auto_enabled():
             self._auto_task = asyncio.create_task(self._auto_loop())
@@ -65,11 +68,15 @@ class NamePossessionPlugin(Star):
             yield event.plain_result("当前群不在可用范围（名单规则）。")
             return
 
+        if not any([self.is_parody_avatar, self.is_parody_nickname]):
+            yield event.plain_result("未启用夺舍群昵称或头像")
+            return
+
         # 获取 Napcat 客户端
         client = event.bot
         self_id = int(event.message_obj.self_id)
 
-        ret = await self.service.random_possess(client, int(group_id), self_id)
+        ret = await self.service.random_possess(client, int(group_id), self_id, self.is_parody_nickname, self.is_parody_avatar)
         if not ret:
             yield event.plain_result("未能选择到合适的群友，稍后再试。")
             return

--- a/service.py
+++ b/service.py
@@ -65,7 +65,7 @@ class NamePossessionService:
         return (card or nickname or "群友").strip()
 
     async def random_possess(
-        self, client, group_id: int, self_id: int
+            self, client, group_id: int, self_id: int, enable_set_nickname=True, enable_set_avatar=False
     ) -> tuple[int, str] | None:
         """Pick a random member and set bot's group card to theirs.
 
@@ -85,10 +85,12 @@ class NamePossessionService:
         target_id = int(target.get("user_id"))
         target_name = self._display_name_of(target)
 
-        if not await self.set_group_card(client, group_id, int(self_id), target_name):
-            return None
+        if enable_set_nickname:
+            if not await self.set_group_card(client, group_id, int(self_id), target_name):
+                return None
 
-        await self.set_avatar(client, target_id)
+        if enable_set_avatar:
+            await self.set_avatar(client, target_id)
 
         # log after successful rename
         logger.info(


### PR DESCRIPTION
## Summary by Sourcery

添加可配置开关，以分别独立控制昵称和头像仿冒行为，并更新附身逻辑以遵循这些设置。

New Features:
- 引入配置标志，用于分别启用或禁用群昵称和头像附身功能。
- 当昵称和头像仿冒功能均被禁用时，禁止手动附身操作。

Enhancements:
- 更新随机附身行为，使其根据新的配置标志有条件地更改昵称和头像。

Documentation:
- 在 README 的配置章节中记录新的昵称和头像仿冒配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable switches to independently control nickname and avatar parody behavior and update possession logic to honor these settings.

New Features:
- Introduce configuration flags to separately enable or disable group nickname and avatar possession.
- Disallow manual possession actions when both nickname and avatar parody features are disabled.

Enhancements:
- Update random possession behavior to conditionally change nickname and avatar based on the new configuration flags.

Documentation:
- Document the new nickname and avatar parody configuration options in the README configuration section.

</details>

新功能：
- 引入配置选项，用于分别切换对群组昵称和头像的模仿（parody）行为。
- 当昵称和头像模仿功能都被禁用时，阻止手动附身操作。

改进：
- 更新附身逻辑，使其遵循新的昵称和头像配置标志，而不是总是同时更改二者。
- 在 README 的配置章节中记录新的配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置开关，以分别独立控制昵称和头像仿冒行为，并更新附身逻辑以遵循这些设置。

New Features:
- 引入配置标志，用于分别启用或禁用群昵称和头像附身功能。
- 当昵称和头像仿冒功能均被禁用时，禁止手动附身操作。

Enhancements:
- 更新随机附身行为，使其根据新的配置标志有条件地更改昵称和头像。

Documentation:
- 在 README 的配置章节中记录新的昵称和头像仿冒配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable switches to independently control nickname and avatar parody behavior and update possession logic to honor these settings.

New Features:
- Introduce configuration flags to separately enable or disable group nickname and avatar possession.
- Disallow manual possession actions when both nickname and avatar parody features are disabled.

Enhancements:
- Update random possession behavior to conditionally change nickname and avatar based on the new configuration flags.

Documentation:
- Document the new nickname and avatar parody configuration options in the README configuration section.

</details>

</details>